### PR TITLE
minor improvements for convenience

### DIFF
--- a/scripts/SF00_miscellaneous.py
+++ b/scripts/SF00_miscellaneous.py
@@ -50,3 +50,25 @@ def write_json(data, file_name, indent=1):
         json.dump(data, handle, indent=indent)
         handle.close()
 
+def check_exe(program):
+    # Based on http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
+    import os
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            print program + ' .. ok'
+            return(program)
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                print program + ' .. ok [' +  exe_file + ']'
+                return(program)
+
+                
+    print program + ' .. failed - required in PATH'
+    exit()

--- a/scripts/SF05_diamond_orthamcl.py
+++ b/scripts/SF05_diamond_orthamcl.py
@@ -1,5 +1,5 @@
 import os,sys,time; from collections import defaultdict,Counter
-from SF00_miscellaneous import times,load_pickle,read_fasta,write_pickle
+from SF00_miscellaneous import times,load_pickle,read_fasta,write_pickle,check_exe
 
 def diamond_run(query_path, output_path, dmd_ref_file, threads, diamond_max_target_seqs):
     """ runn diamond using sensitive alignment mode """
@@ -101,6 +101,10 @@ def diamond_orthamcl_cluster(path, threads, blast_cluster_file_path='none', roar
                                   per query to keep alignments for. Defalut: 
                                   #strain * #max_duplication= 40*15= 600 
     '''
+
+    for exe in ['orthAgogue', 'mcl']:
+        check_exe(exe)
+
     input_path=path+'protein_faa/';
     output_path=input_path+'diamond_matches/';
     threads=str(threads)

--- a/scripts/SF05_diamond_orthamcl.py
+++ b/scripts/SF05_diamond_orthamcl.py
@@ -4,7 +4,7 @@ from SF00_miscellaneous import times,load_pickle,read_fasta,write_pickle
 def diamond_run(query_path, output_path, dmd_ref_file, threads, diamond_max_target_seqs):
     """ runn diamond using sensitive alignment mode """
     os.system('pwd')
-    diam='./tools/diamond'
+    diam=os.path.dirname(os.path.realpath(__file__)) + '/../tools/diamond'
     print '# Run for query.faa'
     start = time.time()
     makedb_command= ''.join([diam,' makedb -p ',threads,' --in ',output_path, dmd_ref_file,' -d ',output_path,'nr > ',output_path,'diamond_makdedb.log  2>&1'])

--- a/scripts/SF06_geneCluster_align_makeTree.py
+++ b/scripts/SF06_geneCluster_align_makeTree.py
@@ -4,7 +4,7 @@ from Bio import Phylo, SeqIO, AlignIO
 from Bio.Seq import Seq; from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
 from ete2 import Tree
-from SF00_miscellaneous import times, read_fasta, load_pickle, write_pickle, write_in_fa, write_json
+from SF00_miscellaneous import times, read_fasta, load_pickle, write_pickle, write_in_fa, write_json, check_exe
 sys.path.append('./scripts/')
 sys.setrecursionlimit(2000)
 
@@ -508,6 +508,10 @@ def cluster_align_makeTree( path, parallel ):
     create gene clusters as nucleotide/ amino_acid fasta files
     and build individual gene trees based on fna files
     """
+
+    for exe in ['mafft', 'fasttree', 'raxml']:
+        check_exe(exe)
+
     def create_geneCluster_fa():
         """ dict storing amino_acid Id/Seq from '.faa' files
             input: '.faa', '_gene_nuc_dict.cpk', '-orthamcl-allclusters.cpk'


### PR DESCRIPTION
Dynamically determine PATH to diamond.

Check that dependencies are in PATH ahead of step execution to prevent long running steps from dying half way through (orthAgogue, mcl, mafft, fasttree, raxml).

```
# log output if mcl missing from PATH
orthAgogue .. ok [/home/thackl/software/orthAgogue/orthAgogue]
mcl .. failed - required in PATH
```