### PR TITLE
Replace treetime submodule by treetime from conda

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "treetime"]
-	path = treetime
-	url = https://github.com/neherlab/treetime

--- a/panX-environment.yml
+++ b/panX-environment.yml
@@ -5,15 +5,14 @@ channels:
 - conda-forge
 dependencies:
 - python=2.7.13
-- biopython=1.66
-- numpy=1.10.4
-- scipy=0.16.1
-- pandas=0.16.2
-- ete2=2.3.10
-
-- diamond=0.8.36
-- fasttree=2.1.9
-- mafft=7.305
-- mcl=14.137
-- raxml=8.2.9
-
+- biopython
+- numpy
+- scipy
+- pandas
+- ete2
+- diamond
+- fasttree
+- mafft
+- mcl
+- raxml
+- treetime

--- a/scripts/sf_gain_loss.py
+++ b/scripts/sf_gain_loss.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division
 import os,sys,copy;import numpy as np
 from collections import defaultdict
 sys.path.append('./')
-from treetime.treetime import treeanc as ta
-from treetime.treetime.gtr import GTR
-from treetime.treetime import io
-from treetime.treetime import seq_utils
+from treetime import treeanc as ta
+from treetime.gtr import GTR
+from treetime import io
+from treetime import seq_utils
 from Bio import Phylo, AlignIO
 from sf_miscellaneous import write_json, write_pickle
 from sf_geneCluster_align_makeTree import load_sorted_clusters

--- a/scripts/sf_geneCluster_align_makeTree.py
+++ b/scripts/sf_geneCluster_align_makeTree.py
@@ -306,7 +306,7 @@ class mpm_tree(object):
 
         if treetime_used:
             # load the resulting tree as a treetime instance
-            from treetime.treetime import TreeAnc
+            from treetime import TreeAnc
             self.tt = TreeAnc(tree=out_fname, aln=self.aln, gtr='Jukes-Cantor', verbose=0)
             # provide short cut to tree and revert names that conflicted with newick format
             self.tree = self.tt.tree


### PR DESCRIPTION
Hi,

This PR replaces the submodule for treetime to use the treetime installed with conda:

- Remove the submodule
- Add treetime in conda environment
- Fix import of treetime

I ran the tests to check.

Bérénice